### PR TITLE
Query highlighting with Delpher

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,13 +133,13 @@ The package contains several text analysis tasks to generate the terms used in t
 
 .. code-block:: bash
 
-  $ ./mange.py construct_tfidf_model gensim_data/immix_summaries.mm gensim_data/immix_summaries.tfidf_model
+  $ ./manage.py construct_tfidf_model gensim_data/immix_summaries.mm gensim_data/immix_summaries.tfidf_model
 
 7. Add the topN 'most descriptive' terms to each indexed document:
 
 .. code-block:: bash
 
-  $ ./mange.py analyze_text index_descriptive_terms "immix_analyzed/summaries/*.tar.gz"  gensim_data/immix_summaries_pruned.dict gensim_data/immix_summaries.tfidf_model gensim_data/immix_summaries.tfidf_model 'quamerdes_immix_20140920' 'text_descriptive_terms' 10
+  $ ./manage.py analyze_text index_descriptive_terms "immix_analyzed/summaries/*.tar.gz"  gensim_data/immix_summaries_pruned.dict gensim_data/immix_summaries.tfidf_model gensim_data/immix_summaries.tfidf_model 'quamerdes_immix_20140920' 'text_descriptive_terms' 10
 
 License
 -------

--- a/avresearcher/static/js/views/search/results_list.js
+++ b/avresearcher/static/js/views/search/results_list.js
@@ -40,6 +40,7 @@ function($, _, Backbone, app, resultsListImmixTemplate, resultsListKbTemplate){
 
             this.$el.find('li').remove();
             this.$el.html(_.template(this.templates[this.model.get('collection')], {
+                query: this.model.get('ftQuery'),
                 hits: this.model.get('hits')
             }));
 

--- a/avresearcher/static/templates/search/results_list_kb.html
+++ b/avresearcher/static/templates/search/results_list_kb.html
@@ -10,8 +10,19 @@
           } else {
             title = '(untitled article)';
           }
+
+          // Bypass the KB resolver and go straight to Delpher. Not only does
+          // the KB resolver add noticeable latency, it also doesn't allow us
+          // to send the query string along.
+          var re = /http:\/\/resolver\.kb\.nl\/resolve\?urn=([^&]*)/;
+          var url = hit.fields.source;
+          var match = re.exec(url);
+          if (match) {
+            url = ('http://www.delpher.nl/nl/kranten/view?coll=ddd&identifier='
+                   + match[1] + '&query=' + encodeURIComponent(query));
+          }
         %>
-        <h2><a href="<%= hit.fields.source %>" target="_blank"><%= title %></a></h2>
+        <h2><a href="<%= url  %>" target="_blank"><%= title %></a></h2>
         <% if ('meta.publication_name' in hit.fields){ %><h3><%= hit.fields['meta.publication_name'] %></h3><% } %>
         <%
             var format = d3.time.format('%a %b %-e, %Y');


### PR DESCRIPTION
This sends the query string to Delpher to get match highlighting there. While a bit of a privacy leak (queries being sent in the open), my users really want this. To do so, it has to skip the KB resolver, but that actually speeds things up considerably.
