### PR TITLE
allow more flexible Elasticsearch configuration (including HTTPS connections)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,15 +54,16 @@ Installing AVResearcherXL
   >>> os.urandom(24)
   '\x86\xb8f\xcc\xbf\xd6f\x96\xf0\x08v\x90\xed\xad\x07\xfa\x01\xd0\\L#\x95\xf6\xdd'
 
-6. Set the URLs and names of the ElasticSearch indexes:
+6. Configure the connections to the Elasticsearch instance(s) and the log index:
 
 .. code-block:: pycon
 
-  ES_SEARCH_HOST = 'localhost'
-  ES_SEARCH_PORT = 9200
-  ES_LOG_HOST = ES_SEARCH_HOST
-  ES_LOG_PORT = ES_SEARCH_PORT
+  ES_SEARCH_CONFIG = {'hosts': ['index_host1', 'index_host2'], 'port': 9200}
+  ES_LOG_CONFIG = {'hosts': ['logging_host'] , 'port': 9200}
   ES_LOG_INDEX = 'avresearcher_logs'
+
+See the comments in ``avresearcher/settings.py`` for more advanced
+configuration options and examples.
 
 7. Set the options of the indexed collections (``COLLECTIONS_CONFIGzz).
 

--- a/README.rst
+++ b/README.rst
@@ -133,13 +133,13 @@ The package contains several text analysis tasks to generate the terms used in t
 
 .. code-block:: bash
 
-  $ ./mange.py construct_tfidf_model gensim_data/immix_summaries.mm gensim_data/immix_summaries.tfidf_model
+  $ ./manage.py construct_tfidf_model gensim_data/immix_summaries.mm gensim_data/immix_summaries.tfidf_model
 
 7. Add the topN 'most descriptive' terms to each indexed document:
 
 .. code-block:: bash
 
-  $ ./mange.py analyze_text index_descriptive_terms "immix_analyzed/summaries/*.tar.gz"  gensim_data/immix_summaries_pruned.dict gensim_data/immix_summaries.tfidf_model gensim_data/immix_summaries.tfidf_model 'quamerdes_immix_20140920' 'text_descriptive_terms' 10
+  $ ./manage.py analyze_text index_descriptive_terms "immix_analyzed/summaries/*.tar.gz"  gensim_data/immix_summaries_pruned.dict gensim_data/immix_summaries.tfidf_model gensim_data/immix_summaries.tfidf_model 'quamerdes_immix_20140920' 'text_descriptive_terms' 10
 
 License
 -------

--- a/avresearcher/app.py
+++ b/avresearcher/app.py
@@ -40,12 +40,8 @@ def create_app(package_name='avresearcher', settings_override=None):
 
     login_manager.setup_app(app)
 
-    app.es_search = Elasticsearch([
-        {'host': app.config['ES_SEARCH_HOST'], 'port': app.config['ES_SEARCH_PORT']}
-    ])
-    app.es_log = Elasticsearch([
-        {'host': app.config['ES_LOG_HOST'], 'port':  app.config['ES_LOG_PORT']}
-    ])
+    app.es_search = Elasticsearch(**app.config['ES_SEARCH_CONFIG'])
+    app.es_log = Elasticsearch(**app.config['ES_LOG_CONFIG'])
 
     for bp in DEFAULT_BLUEPRINTS:
         app.register_blueprint(bp)

--- a/avresearcher/app.py
+++ b/avresearcher/app.py
@@ -41,7 +41,11 @@ def create_app(package_name='avresearcher', settings_override=None):
     login_manager.setup_app(app)
 
     app.es_search = Elasticsearch(**app.config['ES_SEARCH_CONFIG'])
-    app.es_log = Elasticsearch(**app.config['ES_LOG_CONFIG'])
+    log_config = app.config.get('ES_LOG_CONFIG', None)
+    if log_config is not None:
+        app.es_log = Elasticsearch(**log_config)
+    else:
+        app.es_log = None
 
     for bp in DEFAULT_BLUEPRINTS:
         app.register_blueprint(bp)

--- a/avresearcher/settings.py
+++ b/avresearcher/settings.py
@@ -2,14 +2,20 @@ DEBUG = False
 
 SECRET_KEY = ''
 
-# URL of the ElasticSearch instance that contains the AVResearcherXL indexes
-ES_SEARCH_HOST = 'localhost'
-ES_SEARCH_PORT = 9200
+# ElasticSearch instance that contains the document collection(s).
+ES_SEARCH_CONFIG = {'hosts': ['localhost'], 'port': 9200}
 
-# URL of the ElasticSearch instance used to store usage logs (clicks,
-# queries, etc.)
-ES_LOG_HOST = ES_SEARCH_HOST
-ES_LOG_PORT = ES_SEARCH_PORT
+# To connect to an Elasticsearch instance via a secure (HTTPS) connection,
+# use a setting like the following. This works for ES_LOG_CONFIG, too.
+#
+#import certifi
+#ES_SEARCH_CONFIG = {'hosts': ['host1', 'host2'],
+#                    'http_auth': ('username', 's3cr3tp4ssw0rd'),
+#                    'port': 443, 'use_ssl': True,
+#                    'verify_certs': True, 'ca_certs': certifi.where()}
+
+# ElasticSearch instance used to store usage logs (clicks, queries, etc.).
+ES_LOG_CONFIG = ES_SEARCH_CONFIG    # Same instance that holds the collections.
 ES_LOG_INDEX = 'avresearcherxl_logs'
 
 # User database URI

--- a/avresearcher/settings.py
+++ b/avresearcher/settings.py
@@ -15,6 +15,8 @@ ES_SEARCH_CONFIG = {'hosts': ['localhost'], 'port': 9200}
 #                    'verify_certs': True, 'ca_certs': certifi.where()}
 
 # ElasticSearch instance used to store usage logs (clicks, queries, etc.).
+# To disable logs, use:
+# ES_LOG_CONFIG = None
 ES_LOG_CONFIG = ES_SEARCH_CONFIG    # Same instance that holds the collections.
 ES_LOG_INDEX = 'avresearcherxl_logs'
 

--- a/avresearcher/settings.py
+++ b/avresearcher/settings.py
@@ -3,7 +3,7 @@ DEBUG = False
 SECRET_KEY = ''
 
 # ElasticSearch instance that contains the document collection(s).
-ES_SEARCH_CONFIG = {'hosts': ['localhost'], 'port': 9200}
+#ES_SEARCH_CONFIG = {'hosts': ['localhost'], 'port': 9200}
 
 # To connect to an Elasticsearch instance via a secure (HTTPS) connection,
 # use a setting like the following. This works for ES_LOG_CONFIG, too.
@@ -15,10 +15,12 @@ ES_SEARCH_CONFIG = {'hosts': ['localhost'], 'port': 9200}
 #                    'verify_certs': True, 'ca_certs': certifi.where()}
 
 # ElasticSearch instance used to store usage logs (clicks, queries, etc.).
+# This has the same format as ES_SEARCH_CONFIG; use the following to use the
+# same host for logging:
+#ES_LOG_CONFIG = ES_SEARCH_CONFIG
+#ES_LOG_INDEX = 'avresearcherxl_logs'
 # To disable logs, use:
-# ES_LOG_CONFIG = None
-ES_LOG_CONFIG = ES_SEARCH_CONFIG    # Same instance that holds the collections.
-ES_LOG_INDEX = 'avresearcherxl_logs'
+#ES_LOG_CONFIG = None
 
 # User database URI
 SQLALCHEMY_DATABASE_URI = 'mysql://user:pass@host/db'

--- a/avresearcher/tests/test_app.py
+++ b/avresearcher/tests/test_app.py
@@ -1,0 +1,44 @@
+from avresearcher.app import _validate
+
+from copy import deepcopy
+
+from nose.tools import assert_raises
+
+
+config = {
+    "COLLECTIONS_CONFIG": {
+        "index1": {
+            "index_name": "hello?",
+            "enabled_facets": ["cheap_facet"],
+            "available_aggregations": {
+                "cheap_facet": {}
+            },
+            "available_search_fields": {
+                "field1": {"name": "1", "fields": ["1"]},
+                "field2": {"name": "2", "fields": ["2"]},
+            },
+            "enabled_search_fields": ["field1", "field2"],
+        },
+    },
+    "ENABLED_COLLECTIONS": ["index1"],
+}
+
+
+def test_validate():
+    _validate(config)
+
+    c = deepcopy(config)
+    c["ENABLED_COLLECTIONS"] += "index2"
+    assert_raises(ValueError, _validate, c)
+
+    c = deepcopy(config)
+    c["COLLECTIONS_CONFIG"]["index1"]["index_name"] = 123456
+    assert_raises(TypeError, _validate, c)
+
+    c = deepcopy(config)
+    c["COLLECTIONS_CONFIG"]["index1"]["enabled_facets"] += "expensive_facet"
+    assert_raises(ValueError, _validate, c)
+
+    c = deepcopy(config)
+    c["COLLECTIONS_CONFIG"]["index1"]["enabled_search_fields"] += "field3"
+    assert_raises(ValueError, _validate, c)

--- a/avresearcher/views.py
+++ b/avresearcher/views.py
@@ -283,6 +283,11 @@ def count():
 @views.route('/api/log_usage', methods=['POST'])
 @login_required
 def log_usage():
+    success = jsonify({'success': True})
+
+    if current_app.es_log is None:
+        return success
+
     events = json.loads(request.form['events'])
     user_id = current_user.id
 
@@ -295,4 +300,4 @@ def log_usage():
 
     current_app.es_log.bulk(body=bulkrequest)
 
-    return jsonify({'success': True})
+    return success

--- a/manage.py
+++ b/manage.py
@@ -14,7 +14,7 @@ from elasticsearch.helpers import bulk
 
 from avresearcher import create_app
 from avresearcher.extensions import db
-from avresearcher.settings import ES_SEARCH_HOST, ES_SEARCH_PORT
+from avresearcher.settings import ES_SEARCH_CONFIG
 
 
 logging.getLogger('elasticsearch').setLevel(logging.INFO)
@@ -34,7 +34,7 @@ es_log = logging.getLogger('elasticsearch.trace')
 es_log.addHandler(log_sh)
 es_log.setLevel(logging.ERROR)
 
-es = Elasticsearch(host=ES_SEARCH_HOST, port=ES_SEARCH_PORT)
+es = Elasticsearch(**ES_SEARCH_CONFIG)
 
 
 @click.group()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ Flask-Mail==0.9.0
 Flask-SQLAlchemy==1.0
 elasticsearch==1.1.1
 click==2.1
+certifi
 blinker==1.3
 raven==5.1.0
 psycopg2==2.5.4


### PR DESCRIPTION
This is needed to use ES connections over HTTPS. It changes the `settings.py` format, but the old format is still supported for backward compatibility.
